### PR TITLE
pass `verbose` as a main argument to `lgb.train`

### DIFF
--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -88,6 +88,12 @@ train_lightgbm <- function(x, y, max_depth = 17, num_iterations = 10, learning_r
 
   arg_list <- purrr::compact(c(arg_list, others))
 
+  if ("verbose" %in% names(arg_list)) {
+    verbose <- arg_list$verbose
+    arg_list[["verbose"]] <- NULL
+  } else {
+    verbose <- 1L
+  }
 
   d <- lightgbm::lgb.Dataset(
     data = prepare_df_lgbm(x),
@@ -98,7 +104,8 @@ train_lightgbm <- function(x, y, max_depth = 17, num_iterations = 10, learning_r
 
   main_args <- list(
     data = quote(d),
-    params = arg_list
+    params = arg_list,
+    verbose = verbose
   )
 
   call <- parsnip::make_call(fun = "lgb.train", ns = "lightgbm", main_args)


### PR DESCRIPTION
Corrects passage of `verbose` argument from `set_fit`—was previously passed as part of the `param` list rather than as a main argument to `lgb.train` in `train_lightgbm`.

Previous output:

``` r
library(parsnip)
library(bonsai)

ct_fit_1 <-
  boost_tree() %>%
  set_engine("lightgbm") %>%
  set_mode("regression") %>%
  fit(mpg ~ ., data = mtcars)
#> [LightGBM] [Warning] Auto-choosing col-wise multi-threading, the overhead of testing was 0.000021 seconds.
#> You can set `force_col_wise=true` to remove the overhead.
#> [LightGBM] [Info] Total Bins 74
#> [LightGBM] [Info] Number of data points in the train set: 32, number of used features: 10
#> [LightGBM] [Info] Start training from score 20.090625
#> [LightGBM] [Warning] No further splits with positive gain, best gain: -inf
#> [LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
#> [LightGBM] [Warning] No further splits with positive gain, best gain: -inf
#> [LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
#> [LightGBM] [Warning] No further splits with positive gain, best gain: -inf
#> [LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
#> [LightGBM] [Warning] No further splits with positive gain, best gain: -inf
#> [LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
#> [LightGBM] [Warning] No further splits with positive gain, best gain: -inf
#> [LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
#> [LightGBM] [Warning] No further splits with positive gain, best gain: -inf
#> [LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
#> [LightGBM] [Warning] No further splits with positive gain, best gain: -inf
#> [LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
#> [LightGBM] [Warning] No further splits with positive gain, best gain: -inf
#> [LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
#> [LightGBM] [Warning] No further splits with positive gain, best gain: -inf
#> [LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
#> [LightGBM] [Warning] No further splits with positive gain, best gain: -inf
#> [LightGBM] [Warning] Stopped training because there are no more leaves that meet the split requirements
```

<sup>Created on 2022-05-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Is now:

``` r
library(parsnip)
library(bonsai)

ct_fit_1 <-
  boost_tree() %>%
  set_engine("lightgbm") %>%
  set_mode("regression") %>%
  fit(mpg ~ ., data = mtcars)
```

<sup>Created on 2022-05-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>