### PR TITLE
make wrapped results replicate fits via lightgbm

### DIFF
--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -21,7 +21,7 @@
 #' @return A fitted `lightgbm.Model` object.
 #' @keywords internal
 #' @export
-train_lightgbm <- function(x, y, max_depth = 17, num_iterations = 10, learning_rate = 0.1,
+train_lightgbm <- function(x, y, max_depth = -1, num_iterations = 100, learning_rate = 0.1,
                            feature_fraction = 1, min_data_in_leaf = 20,
                            min_gain_to_split = 0, bagging_fraction = 1,
                            quiet = FALSE, ...) {
@@ -33,30 +33,19 @@ train_lightgbm <- function(x, y, max_depth = 17, num_iterations = 10, learning_r
     rlang::abort("'quiet' should be a logical value.")
   }
 
-  if(!is.null(feature_fraction)) {
-    feature_fraction <- feature_fraction/ncol(x)
-  }
-  if(feature_fraction > 1) {
-    feature_fraction <- 1
-  }
-
-  if (bagging_fraction > 1) {
-    bagging_fraction <- 1
-  }
-
   if (!any(names(others) %in% c("objective"))) {
     if (is.numeric(y)) {
-      others$num_class <- 1
+      #others$num_class <- 1
       others$objective <- "regression"
     } else {
       lvl <- levels(y)
       lvls <- length(lvl)
       y <- as.numeric(y) - 1
       if (lvls == 2) {
-        others$num_class <- 1
+        #others$num_class <- 1
         others$objective <- "binary"
       } else {
-        others$num_class <- lvls
+        #others$num_class <- lvls
         others$objective <- "multiclass"
       }
     }
@@ -76,15 +65,6 @@ train_lightgbm <- function(x, y, max_depth = 17, num_iterations = 10, learning_r
 
   # parallelism should be explicitly specified by the user
   if(all(sapply(others[c("num_threads", "num_thread", "nthread", "nthreads", "n_jobs")], is.null))) others$num_threads <- 1L
-
-  if (max_depth > 17) {
-    warning("max_depth > 17, num_leaves truncated to 2^17 - 1")
-    max_depth <- 17
-  }
-
-  if (is.null(others$num_leaves)) {
-    others$num_leaves = max(2^max_depth - 1, 2)
-  }
 
   arg_list <- purrr::compact(c(arg_list, others))
 

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -35,7 +35,6 @@ train_lightgbm <- function(x, y, max_depth = -1, num_iterations = 100, learning_
 
   if (!any(names(others) %in% c("objective"))) {
     if (is.numeric(y)) {
-      #others$num_class <- 1
       others$objective <- "regression"
     } else {
       lvl <- levels(y)

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -42,10 +42,10 @@ train_lightgbm <- function(x, y, max_depth = -1, num_iterations = 100, learning_
       lvls <- length(lvl)
       y <- as.numeric(y) - 1
       if (lvls == 2) {
-        #others$num_class <- 1
+        others$num_class <- 1
         others$objective <- "binary"
       } else {
-        #others$num_class <- lvls
+        others$num_class <- lvls
         others$objective <- "multiclass"
       }
     }

--- a/man/train_lightgbm.Rd
+++ b/man/train_lightgbm.Rd
@@ -7,8 +7,8 @@
 train_lightgbm(
   x,
   y,
-  max_depth = 17,
-  num_iterations = 10,
+  max_depth = -1,
+  num_iterations = 100,
   learning_rate = 0.1,
   feature_fraction = 1,
   min_data_in_leaf = 20,

--- a/tests/testthat/_snaps/lightgbm.md
+++ b/tests/testthat/_snaps/lightgbm.md
@@ -1,0 +1,24 @@
+# boost_tree with lightgbm
+
+    Code
+      boost_tree() %>% set_engine("lightgbm") %>% set_mode("regression")
+    Output
+      Boosted Tree Model Specification (regression)
+      
+      Computational engine: lightgbm 
+      
+
+---
+
+    Code
+      boost_tree() %>% set_engine("lightgbm", nrounds = 100) %>% set_mode(
+        "classification")
+    Output
+      Boosted Tree Model Specification (classification)
+      
+      Engine-Specific Arguments:
+        nrounds = 100
+      
+      Computational engine: lightgbm 
+      
+

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -52,14 +52,14 @@ test_that("boost_tree with lightgbm",{
       categorical_feature = c(1L, 2L, 6L)
     )
 
-  params <- list(
+  params_1 <- list(
     objective = "regression"
   )
 
   lgbm_fit_1 <-
     lightgbm::lgb.train(
       data = peng_x,
-      params = params,
+      params = params_1,
       verbose = -1
     )
 
@@ -68,14 +68,70 @@ test_that("boost_tree with lightgbm",{
   expect_equal(pars_preds_1$.pred, lgbm_preds_1)
 
 
-  # do the same with primary argument
+  # regression, adjusting a primary argument
+  expect_error_free({
+    pars_fit_2 <-
+      boost_tree(trees = 20) %>%
+      set_engine("lightgbm") %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)
+  })
 
-  # do the same with engine argument
+  expect_error_free({
+    pars_preds_2 <-
+      predict(pars_fit_2, penguins)
+  })
+
+  params_2 <- list(
+    objective = "regression",
+    num_iterations = 20
+  )
+
+  lgbm_fit_2 <-
+    lightgbm::lgb.train(
+      data = peng_x,
+      params = params_2,
+      verbose = -1
+    )
+
+  lgbm_preds_2 <- predict(lgbm_fit_2, peng_m)
+
+  expect_equal(pars_preds_2$.pred, lgbm_preds_2)
+
+  # regression, adjusting an engine argument
+  expect_error_free({
+    pars_fit_3 <-
+      boost_tree() %>%
+      set_engine("lightgbm", lambda_l2 = .5) %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)
+  })
+
+  expect_error_free({
+    pars_preds_3 <-
+      predict(pars_fit_3, penguins)
+  })
+
+  params_3 <- list(
+    objective = "regression",
+    lambda_l2 = .5
+  )
+
+  lgbm_fit_3 <-
+    lightgbm::lgb.train(
+      data = peng_x,
+      params = params_3,
+      verbose = -1
+    )
+
+  lgbm_preds_3 <- predict(lgbm_fit_3, peng_m)
+
+  expect_equal(pars_preds_3$.pred, lgbm_preds_3)
 
   # ----------------------------------------------------------------------------
   # classification
 
-  # do the same with classification
+
 
 })
 

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -1,0 +1,82 @@
+test_that("boost_tree with lightgbm",{
+  skip_if_not_installed("lightgbm")
+  skip_if_not_installed("modeldata")
+
+  library(lightgbm)
+  library(modeldata)
+  library(dplyr)
+
+  data("penguins", package = "modeldata")
+
+  penguins <- penguins[complete.cases(penguins),]
+
+  expect_snapshot(
+    boost_tree() %>% set_engine("lightgbm") %>% set_mode("regression")
+  )
+  expect_snapshot(
+    boost_tree() %>% set_engine("lightgbm", nrounds = 100) %>% set_mode("classification")
+  )
+
+  # ----------------------------------------------------------------------------
+  # regression
+
+  expect_error_free({
+    pars_fit_1 <-
+      boost_tree() %>%
+      set_engine("lightgbm") %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)
+  })
+
+  expect_error_free({
+    pars_preds_1 <-
+      predict(pars_fit_1, penguins)
+  })
+
+  peng <-
+    penguins %>%
+    mutate(across(where(is.character), ~as.factor(.x))) %>%
+    mutate(across(where(is.factor), ~as.integer(.x) - 1))
+
+  peng_y <- peng$bill_length_mm
+
+  peng_m <- peng %>%
+    select(-bill_length_mm) %>%
+    as.matrix()
+
+  peng_x <-
+    lgb.Dataset(
+      data = peng_m,
+      label = peng_y,
+      params = list(feature_pre_filter = FALSE),
+      categorical_feature = c(1L, 2L, 6L)
+    )
+
+  params <- list(
+    objective = "regression"
+  )
+
+  lgbm_fit_1 <-
+    lightgbm::lgb.train(
+      data = peng_x,
+      params = params,
+      verbose = -1
+    )
+
+  lgbm_preds_1 <- predict(lgbm_fit_1, peng_m)
+
+  expect_equal(pars_preds_1$.pred, lgbm_preds_1)
+
+
+  # do the same with primary argument
+
+  # do the same with engine argument
+
+  # ----------------------------------------------------------------------------
+  # classification
+
+  # do the same with classification
+
+})
+
+


### PR DESCRIPTION
The internals of `train_lightgbm` previously set different defaults than `lightgbm::lgb.train` and overwrote some inputs.

This is a first go at making sure we replicate `lightgbm`'s results with our wrappers by default.

One question so far: bonsai has already dropped rows that aren't complete cases by the time data arrives in `train_lightgbm` via `set_fit`. Is this expected behavior?