### PR TITLE
move parsnip to depends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,12 +15,13 @@ Authors@R: c(
 Description: Bindings for additional tree-based model engines for use with the 
     'parsnip' package. 
 License: TBD
+Depends:
+    parsnip (>= 0.2.1.9001)
 Imports: 
     dplyr,
     purrr,
     rlang,
     tibble,
-    parsnip (>= 0.2.1.9001),
     stats,
     dials,
     generics,
@@ -34,7 +35,7 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.1.2.9000
 URL: https://bonsai.tidymodels.org/, https://github.com/tidymodels/bonsai
 BugReports: https://github.com/tidymodels/bonsai/issues
 Config/Needs/website: tidyverse/tidytemplate

--- a/bonsai.Rproj
+++ b/bonsai.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
It needs to be fully attached so that the model info can be put into the parsnip database. 