### PR TITLE
refine lightgbm's `mtry` support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,8 @@ Suggests:
     lightgbm,
     partykit,
     modeldata,
+    tune,
+    rsample,
     covr,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -124,6 +124,7 @@ process_mtry <- function(feature_fraction, counts, x, is_missing) {
         "{ineq} than or equal to 1. \n\n`mtry` is currently being interpreted ",
         "as a {interp} rather than a {opp}. Supply `counts = {!counts}` to ",
         "`set_engine` to supply this argument as a {opp} rather than ",
+        # TODO: link to parsnip's lightgbm docs instead here
         "a {interp}. \n\nSee `?train_lightgbm` for more details."
       ),
       call = NULL

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -10,13 +10,19 @@
 #' @param max_depth An integer for the maximum depth of the tree.
 #' @param num_iterations An integer for the number of boosting iterations.
 #' @param learning_rate A numeric value between zero and one to control the learning rate.
-#' @param feature_fraction Subsampling proportion of columns.
+#' @param feature_fraction Fraction of predictors that will be randomly sampled
+#' at each split.
 #' @param min_data_in_leaf A numeric value for the minimum sum of instances needed
 #'  in a child to continue to split.
 #' @param min_gain_to_split A number for the minimum loss reduction required to make a
 #'  further partition on a leaf node of the tree.
 #' @param bagging_fraction Subsampling proportion of rows.
 #' @param quiet A logical; should logging by [lightgbm::lgb.train()] be muted?
+#' @param counts A logical; should `feature_fraction` be interpreted as the
+#' _number_ of predictors that will be randomly sampled at each split?
+#' `TRUE` indicates that `mtry` will be interpreted in its sense as a _count_,
+#' `FALSE` indicates that the argument will be interpreted in its sense as a
+#' _proportion_.
 #' @param ... Other options to pass to [lightgbm::lgb.train()].
 #' @return A fitted `lightgbm.Model` object.
 #' @keywords internal
@@ -24,7 +30,7 @@
 train_lightgbm <- function(x, y, max_depth = -1, num_iterations = 100, learning_rate = 0.1,
                            feature_fraction = 1, min_data_in_leaf = 20,
                            min_gain_to_split = 0, bagging_fraction = 1,
-                           quiet = FALSE, ...) {
+                           counts = TRUE, quiet = FALSE, ...) {
 
   force(x)
   force(y)
@@ -32,6 +38,10 @@ train_lightgbm <- function(x, y, max_depth = -1, num_iterations = 100, learning_
   if (!is.logical(quiet)) {
     rlang::abort("'quiet' should be a logical value.")
   }
+
+  feature_fraction <-
+    process_mtry(feature_fraction = feature_fraction,
+                 counts = counts, x = x, is_missing = missing(feature_fraction))
 
   if (!any(names(others) %in% c("objective"))) {
     if (is.numeric(y)) {
@@ -98,6 +108,46 @@ train_lightgbm <- function(x, y, max_depth = -1, num_iterations = 100, learning_
   res
 }
 
+process_mtry <- function(feature_fraction, counts, x, is_missing) {
+  if (!is.logical(counts)) {
+    rlang::abort("'counts' should be a logical value.")
+  }
+
+  ineq <- if (counts) {"greater"} else {"less"}
+  interp <- if (counts) {"count"} else {"proportion"}
+  opp <- if (!counts) {"count"} else {"proportion"}
+
+  if ((feature_fraction < 1 & counts) | (feature_fraction > 1 & !counts)) {
+    rlang::abort(
+      glue::glue(
+        "The supplied argument `mtry = {feature_fraction}` must be ",
+        "{ineq} than or equal to 1. \n\n`mtry` is currently being interpreted ",
+        "as a {interp} rather than a {opp}. Supply `counts = {!counts}` to ",
+        "`set_engine` to supply this argument as a {opp} rather than ",
+        "a {interp}. \n\nSee `?train_lightgbm` for more details."
+      ),
+      call = NULL
+    )
+  }
+
+  if (rlang::is_call(feature_fraction)) {
+    if (rlang::call_name(feature_fraction) == "tune") {
+      rlang::abort(
+        glue::glue(
+          "The supplied `mtry` parameter is a call to `tune`. Did you forget ",
+          "to optimize hyperparameters with a tuning function like `tune::tune_grid`?"
+        ),
+        call = NULL
+      )
+    }
+  }
+
+  if (counts && !is_missing) {
+    feature_fraction <- feature_fraction / ncol(x)
+  }
+
+  feature_fraction
+}
 
 #' Internal functions
 #'

--- a/man/train_lightgbm.Rd
+++ b/man/train_lightgbm.Rd
@@ -14,6 +14,7 @@ train_lightgbm(
   min_data_in_leaf = 20,
   min_gain_to_split = 0,
   bagging_fraction = 1,
+  counts = TRUE,
   quiet = FALSE,
   ...
 )
@@ -29,7 +30,8 @@ train_lightgbm(
 
 \item{learning_rate}{A numeric value between zero and one to control the learning rate.}
 
-\item{feature_fraction}{Subsampling proportion of columns.}
+\item{feature_fraction}{Fraction of predictors that will be randomly sampled
+at each split.}
 
 \item{min_data_in_leaf}{A numeric value for the minimum sum of instances needed
 in a child to continue to split.}
@@ -38,6 +40,12 @@ in a child to continue to split.}
 further partition on a leaf node of the tree.}
 
 \item{bagging_fraction}{Subsampling proportion of rows.}
+
+\item{counts}{A logical; should \code{feature_fraction} be interpreted as the
+\emph{number} of predictors that will be randomly sampled at each split?
+\code{TRUE} indicates that \code{mtry} will be interpreted in its sense as a \emph{count},
+\code{FALSE} indicates that the argument will be interpreted in its sense as a
+\emph{proportion}.}
 
 \item{quiet}{A logical; should logging by \code{\link[lightgbm:lgb.train]{lightgbm::lgb.train()}} be muted?}
 

--- a/tests/testthat/_snaps/lightgbm.md
+++ b/tests/testthat/_snaps/lightgbm.md
@@ -22,3 +22,42 @@
       Computational engine: lightgbm 
       
 
+# bonsai handles mtry vs mtry_prop gracefully
+
+    The supplied argument `mtry = 0.5` must be greater than or equal to 1. 
+    
+    `mtry` is currently being interpreted as a count rather than a proportion. Supply `counts = FALSE` to `set_engine` to supply this argument as a proportion rather than a count. 
+    
+    See `?train_lightgbm` for more details.
+
+---
+
+    The supplied argument `mtry = 3` must be less than or equal to 1. 
+    
+    `mtry` is currently being interpreted as a proportion rather than a count. Supply `counts = TRUE` to `set_engine` to supply this argument as a count rather than a proportion. 
+    
+    See `?train_lightgbm` for more details.
+
+---
+
+    Code
+      pars_fit_8 <- boost_tree(mtry = 0.5) %>% set_engine("lightgbm",
+        feature_fraction = 0.5) %>% set_mode("regression") %>% fit(bill_length_mm ~ .,
+      data = penguins)
+    Warning <rlang_warning>
+      The following arguments cannot be manually modified and were removed: feature_fraction.
+    Error <rlang_error>
+      The supplied argument `mtry = 0.5` must be greater than or equal to 1. 
+      
+      `mtry` is currently being interpreted as a count rather than a proportion. Supply `counts = FALSE` to `set_engine` to supply this argument as a proportion rather than a count. 
+      
+      See `?train_lightgbm` for more details.
+
+# tuning mtry vs mtry_prop
+
+    Code
+      boost_tree(mtry = tune::tune()) %>% set_engine("lightgbm") %>% set_mode(
+        "regression") %>% fit(bill_length_mm ~ ., data = penguins)
+    Error <rlang_error>
+      The supplied `mtry` parameter is a call to `tune`. Did you forget to optimize hyperparameters with a tuning function like `tune::tune_grid`?
+

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -235,3 +235,161 @@ test_that("boost_tree with lightgbm",{
 })
 
 
+test_that("bonsai handles mtry vs mtry_prop gracefully", {
+  skip_if_not_installed("modeldata")
+
+  data("penguins", package = "modeldata")
+
+  penguins <- penguins[complete.cases(penguins),]
+
+  # supply no mtry
+  expect_error_free({
+    pars_fit_1 <-
+      boost_tree() %>%
+      set_engine("lightgbm") %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)
+  })
+
+  expect_equal(
+    extract_fit_engine(pars_fit_1)$params$feature_fraction,
+    1
+  )
+
+  # supply mtry = 1 (edge cases)
+  expect_error_free({
+    pars_fit_2 <-
+      boost_tree(mtry = 1) %>%
+      set_engine("lightgbm", counts = TRUE) %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)
+  })
+
+  expect_equal(
+    extract_fit_engine(pars_fit_2)$params$feature_fraction,
+    1 / (ncol(penguins) - 1)
+  )
+
+  expect_error_free({
+    pars_fit_3 <-
+      boost_tree(mtry = 1) %>%
+      set_engine("lightgbm", counts = FALSE) %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)
+  })
+
+  expect_equal(
+    extract_fit_engine(pars_fit_3)$params$feature_fraction,
+    1
+  )
+
+  # supply a count (with default counts = TRUE)
+  expect_error_free({
+    pars_fit_4 <-
+      boost_tree(mtry = 3) %>%
+      set_engine("lightgbm") %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)
+  })
+
+  expect_equal(
+    extract_fit_engine(pars_fit_4)$params$feature_fraction,
+    3 / (ncol(penguins) - 1)
+  )
+
+  # supply a proportion when count expected
+  expect_snapshot_error({
+    pars_fit_5 <-
+      boost_tree(mtry = .5) %>%
+      set_engine("lightgbm") %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)
+  })
+
+  # supply a count when proportion expected
+  expect_snapshot_error({
+    pars_fit_6 <-
+      boost_tree(mtry = 3) %>%
+      set_engine("lightgbm", counts = FALSE) %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)
+  })
+
+  # supply a feature fraction argument rather than mtry
+  # TODO: is there any way to extend parsnip's warning here to
+  # point users to mtry?
+  expect_warning({
+    pars_fit_7 <-
+      boost_tree() %>%
+      set_engine("lightgbm", feature_fraction = .5) %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)},
+    "manually modified and were removed: feature_fraction."
+  )
+
+  expect_equal(
+    extract_fit_engine(pars_fit_7)$params$feature_fraction,
+    1
+  )
+
+  # supply both feature fraction and mtry
+  expect_snapshot({
+    pars_fit_8 <-
+      boost_tree(mtry = .5) %>%
+      set_engine("lightgbm", feature_fraction = .5) %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)},
+    error = TRUE
+  )
+
+  expect_warning({
+    pars_fit_9 <-
+      boost_tree(mtry = 2) %>%
+      set_engine("lightgbm", feature_fraction = .5) %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)},
+    "manually modified and were removed: feature_fraction."
+  )
+
+  expect_equal(
+    extract_fit_engine(pars_fit_9)$params$feature_fraction,
+    2 / (ncol(penguins) - 1)
+  )
+})
+
+test_that("tuning mtry vs mtry_prop", {
+  skip_if_not_installed("tune")
+  skip_if_not_installed("rsample")
+  skip_if_not_installed("modeldata")
+
+  data("penguins", package = "modeldata")
+
+  penguins <- penguins[complete.cases(penguins),]
+
+  suppressMessages(
+    expect_error_free({
+      gbm_tune <- tune::tune_grid(
+        boost_tree(mtry = tune::tune()) %>%
+          set_engine("lightgbm") %>%
+          set_mode("regression"),
+        grid = 4,
+        preprocessor = bill_length_mm ~ .,
+        resamples = rsample::bootstraps(penguins, times = 5)
+      )
+    })
+  )
+
+  mtrys <- unique(tune::collect_metrics(gbm_tune)$mtry)
+
+  expect_equal(length(mtrys), 4)
+  expect_true(all(mtrys >= 1))
+
+  # supply tune() without tuning
+  expect_snapshot({
+    boost_tree(mtry = tune::tune()) %>%
+      set_engine("lightgbm") %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)},
+    error = TRUE
+  )
+})


### PR DESCRIPTION
`boost_tree` with `engine = "lightgbm"` now fully supports `mtry`, including tuning. Some examples adapted from tests:

``` r
library(bonsai)
#> Loading required package: parsnip

data("penguins", package = "modeldata")
penguins <- penguins[complete.cases(penguins),]

# handles defaults and both interfaces -----------------------------
pars_fit_1 <-
  boost_tree() %>%
  set_engine("lightgbm") %>%
  set_mode("regression") %>%
  fit(bill_length_mm ~ ., data = penguins)

extract_fit_engine(pars_fit_1)$params$feature_fraction
#> [1] 1

pars_fit_2 <-
  boost_tree(mtry = 3) %>%
  set_engine("lightgbm") %>%
  set_mode("regression") %>%
  fit(bill_length_mm ~ ., data = penguins)

extract_fit_engine(pars_fit_2)$params$feature_fraction
#> [1] 0.5

pars_fit_3 <-
  boost_tree(mtry = .5) %>%
  set_engine("lightgbm", counts = FALSE) %>%
  set_mode("regression") %>%
  fit(bill_length_mm ~ ., data = penguins)

extract_fit_engine(pars_fit_3)$params$feature_fraction
#> [1] 0.5

# errors informatively --------------------------------------------
boost_tree(mtry = .5) %>%
  set_engine("lightgbm") %>%
  set_mode("regression") %>%
  fit(bill_length_mm ~ ., data = penguins)
#> Error:
#> ! The supplied argument `mtry = 0.5` must be greater than or equal to 1. 
#> 
#> `mtry` is currently being interpreted as a count rather than a proportion. Supply `counts = FALSE` to `set_engine` to supply this argument as a proportion rather than a count. 
#> 
#> See `?train_lightgbm` for more details.

boost_tree(mtry = 3) %>%
  set_engine("lightgbm", counts = FALSE) %>%
  set_mode("regression") %>%
  fit(bill_length_mm ~ ., data = penguins)
#> Error:
#> ! The supplied argument `mtry = 3` must be less than or equal to 1. 
#> 
#> `mtry` is currently being interpreted as a proportion rather than a count. Supply `counts = TRUE` to `set_engine` to supply this argument as a count rather than a proportion. 
#> 
#> See `?train_lightgbm` for more details.

# can be tuned --------------------------------------------------
library(tune)
library(rsample)

gbm_tune <- tune_grid(
  boost_tree(mtry = tune()) %>%
    set_engine("lightgbm") %>%
    set_mode("regression"),
  grid = 4,
  preprocessor = bill_length_mm ~ .,
  resamples = bootstraps(penguins, times = 5)
)
#> i Creating pre-processing data to finalize unknown parameter: mtry

collect_metrics(gbm_tune)
#> # A tibble: 6 × 7
#>    mtry .metric .estimator  mean     n std_err .config             
#>   <int> <chr>   <chr>      <dbl> <int>   <dbl> <chr>               
#> 1     5 rmse    standard   2.56      5 0.0720  Preprocessor1_Model1
#> 2     5 rsq     standard   0.796     5 0.00871 Preprocessor1_Model1
#> 3     3 rmse    standard   2.54      5 0.0723  Preprocessor1_Model2
#> 4     3 rsq     standard   0.800     5 0.00882 Preprocessor1_Model2
#> 5     2 rmse    standard   2.65      5 0.0637  Preprocessor1_Model3
#> 6     2 rsq     standard   0.782     5 0.00856 Preprocessor1_Model3
```

<sup>Created on 2022-05-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


More edge cases there.