### PR TITLE
correct mapping of `mtry` in lightgbm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 To be released as 0.1.1.
 
+* Corrected mapping of the `mtry` argument in `boost_tree` with the lightgbm 
+  engine. `mtry` previously mapped to the `feature_fraction` argument to
+  `lgb.train` but was documented as mapping to an argument more closely 
+  resembling `feature_fraction_bynode`. `mtry` now maps 
+  to `feature_fraction_bynode`.
+  
+  This means that code that set `feature_fraction_bynode` as an argument to
+  `set_engine()` will now error, and the user can now pass `feature_fraction`
+  to `set_engine()` without raising an error. 
+  
+
 # bonsai 0.1.0
 
 Initial release!

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -10,7 +10,7 @@
 #' @param max_depth An integer for the maximum depth of the tree.
 #' @param num_iterations An integer for the number of boosting iterations.
 #' @param learning_rate A numeric value between zero and one to control the learning rate.
-#' @param feature_fraction Fraction of predictors that will be randomly sampled
+#' @param feature_fraction_bynode Fraction of predictors that will be randomly sampled
 #' at each split.
 #' @param min_data_in_leaf A numeric value for the minimum sum of instances needed
 #'  in a child to continue to split.
@@ -21,7 +21,7 @@
 #' the objective function occur before training should be halted.
 #' @param validation The _proportion_ of the training data that are used for
 #' performance assessment and potential early stopping.
-#' @param counts A logical; should `feature_fraction` be interpreted as the
+#' @param counts A logical; should `feature_fraction_bynode` be interpreted as the
 #' _number_ of predictors that will be randomly sampled at each split?
 #' `TRUE` indicates that `mtry` will be interpreted in its sense as a _count_,
 #' `FALSE` indicates that the argument will be interpreted in its sense as a
@@ -34,7 +34,7 @@
 #' @keywords internal
 #' @export
 train_lightgbm <- function(x, y, max_depth = -1, num_iterations = 100, learning_rate = 0.1,
-                           feature_fraction = 1, min_data_in_leaf = 20,
+                           feature_fraction_bynode = 1, min_data_in_leaf = 20,
                            min_gain_to_split = 0, bagging_fraction = 1,
                            early_stopping_rounds = NULL, validation = 0,
                            counts = TRUE, quiet = FALSE, ...) {
@@ -46,16 +46,16 @@ train_lightgbm <- function(x, y, max_depth = -1, num_iterations = 100, learning_
     rlang::abort("'quiet' should be a logical value.")
   }
 
-  feature_fraction <-
-    process_mtry(feature_fraction = feature_fraction,
-                 counts = counts, x = x, is_missing = missing(feature_fraction))
+  feature_fraction_bynode <-
+    process_mtry(feature_fraction_bynode = feature_fraction_bynode,
+                 counts = counts, x = x, is_missing = missing(feature_fraction_bynode))
 
   args <- list(
     param = list(
       num_iterations = num_iterations,
       learning_rate = learning_rate,
       max_depth = max_depth,
-      feature_fraction = feature_fraction,
+      feature_fraction_bynode = feature_fraction_bynode,
       min_data_in_leaf = min_data_in_leaf,
       min_gain_to_split = min_gain_to_split,
       bagging_fraction = bagging_fraction
@@ -101,7 +101,7 @@ train_lightgbm <- function(x, y, max_depth = -1, num_iterations = 100, learning_
   res
 }
 
-process_mtry <- function(feature_fraction, counts, x, is_missing) {
+process_mtry <- function(feature_fraction_bynode, counts, x, is_missing) {
   if (!is.logical(counts)) {
     rlang::abort("'counts' should be a logical value.")
   }
@@ -110,10 +110,10 @@ process_mtry <- function(feature_fraction, counts, x, is_missing) {
   interp <- if (counts) {"count"} else {"proportion"}
   opp <- if (!counts) {"count"} else {"proportion"}
 
-  if ((feature_fraction < 1 & counts) | (feature_fraction > 1 & !counts)) {
+  if ((feature_fraction_bynode < 1 & counts) | (feature_fraction_bynode > 1 & !counts)) {
     rlang::abort(
       glue::glue(
-        "The supplied argument `mtry = {feature_fraction}` must be ",
+        "The supplied argument `mtry = {feature_fraction_bynode}` must be ",
         "{ineq} than or equal to 1. \n\n`mtry` is currently being interpreted ",
         "as a {interp} rather than a {opp}. Supply `counts = {!counts}` to ",
         "`set_engine` to supply this argument as a {opp} rather than ",
@@ -124,8 +124,8 @@ process_mtry <- function(feature_fraction, counts, x, is_missing) {
     )
   }
 
-  if (rlang::is_call(feature_fraction)) {
-    if (rlang::call_name(feature_fraction) == "tune") {
+  if (rlang::is_call(feature_fraction_bynode)) {
+    if (rlang::call_name(feature_fraction_bynode) == "tune") {
       rlang::abort(
         glue::glue(
           "The supplied `mtry` parameter is a call to `tune`. Did you forget ",
@@ -137,10 +137,10 @@ process_mtry <- function(feature_fraction, counts, x, is_missing) {
   }
 
   if (counts && !is_missing) {
-    feature_fraction <- feature_fraction / ncol(x)
+    feature_fraction_bynode <- feature_fraction_bynode / ncol(x)
   }
 
-  feature_fraction
+  feature_fraction_bynode
 }
 
 process_objective_function <- function(args, x, y) {

--- a/R/lightgbm_data.R
+++ b/R/lightgbm_data.R
@@ -188,7 +188,7 @@ make_boost_tree_lightgbm <- function() {
     model = "boost_tree",
     eng = "lightgbm",
     parsnip = "mtry",
-    original = "feature_fraction",
+    original = "feature_fraction_bynode",
     func = list(pkg = "dials", fun = "mtry"),
     has_submodel = FALSE
   )

--- a/man/train_lightgbm.Rd
+++ b/man/train_lightgbm.Rd
@@ -10,7 +10,7 @@ train_lightgbm(
   max_depth = -1,
   num_iterations = 100,
   learning_rate = 0.1,
-  feature_fraction = 1,
+  feature_fraction_bynode = 1,
   min_data_in_leaf = 20,
   min_gain_to_split = 0,
   bagging_fraction = 1,
@@ -32,7 +32,7 @@ train_lightgbm(
 
 \item{learning_rate}{A numeric value between zero and one to control the learning rate.}
 
-\item{feature_fraction}{Fraction of predictors that will be randomly sampled
+\item{feature_fraction_bynode}{Fraction of predictors that will be randomly sampled
 at each split.}
 
 \item{min_data_in_leaf}{A numeric value for the minimum sum of instances needed
@@ -49,7 +49,7 @@ the objective function occur before training should be halted.}
 \item{validation}{The \emph{proportion} of the training data that are used for
 performance assessment and potential early stopping.}
 
-\item{counts}{A logical; should \code{feature_fraction} be interpreted as the
+\item{counts}{A logical; should \code{feature_fraction_bynode} be interpreted as the
 \emph{number} of predictors that will be randomly sampled at each split?
 \code{TRUE} indicates that \code{mtry} will be interpreted in its sense as a \emph{count},
 \code{FALSE} indicates that the argument will be interpreted in its sense as a

--- a/tests/testthat/_snaps/lightgbm.md
+++ b/tests/testthat/_snaps/lightgbm.md
@@ -42,10 +42,10 @@
 
     Code
       pars_fit_8 <- boost_tree(mtry = 0.5) %>% set_engine("lightgbm",
-        feature_fraction = 0.5) %>% set_mode("regression") %>% fit(bill_length_mm ~ .,
-      data = penguins)
+        feature_fraction_bynode = 0.5) %>% set_mode("regression") %>% fit(
+        bill_length_mm ~ ., data = penguins)
     Warning <rlang_warning>
-      The following arguments cannot be manually modified and were removed: feature_fraction.
+      The following arguments cannot be manually modified and were removed: feature_fraction_bynode.
     Error <rlang_error>
       The supplied argument `mtry = 0.5` must be greater than or equal to 1. 
       

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -253,7 +253,7 @@ test_that("bonsai handles mtry vs mtry_prop gracefully", {
   })
 
   expect_equal(
-    extract_fit_engine(pars_fit_1)$params$feature_fraction,
+    extract_fit_engine(pars_fit_1)$params$feature_fraction_bynode,
     1
   )
 
@@ -267,7 +267,7 @@ test_that("bonsai handles mtry vs mtry_prop gracefully", {
   })
 
   expect_equal(
-    extract_fit_engine(pars_fit_2)$params$feature_fraction,
+    extract_fit_engine(pars_fit_2)$params$feature_fraction_bynode,
     1 / (ncol(penguins) - 1)
   )
 
@@ -280,7 +280,7 @@ test_that("bonsai handles mtry vs mtry_prop gracefully", {
   })
 
   expect_equal(
-    extract_fit_engine(pars_fit_3)$params$feature_fraction,
+    extract_fit_engine(pars_fit_3)$params$feature_fraction_bynode,
     1
   )
 
@@ -294,7 +294,7 @@ test_that("bonsai handles mtry vs mtry_prop gracefully", {
   })
 
   expect_equal(
-    extract_fit_engine(pars_fit_4)$params$feature_fraction,
+    extract_fit_engine(pars_fit_4)$params$feature_fraction_bynode,
     3 / (ncol(penguins) - 1)
   )
 
@@ -322,14 +322,14 @@ test_that("bonsai handles mtry vs mtry_prop gracefully", {
   expect_warning({
     pars_fit_7 <-
       boost_tree() %>%
-      set_engine("lightgbm", feature_fraction = .5) %>%
+      set_engine("lightgbm", feature_fraction_bynode = .5) %>%
       set_mode("regression") %>%
       fit(bill_length_mm ~ ., data = penguins)},
-    "manually modified and were removed: feature_fraction."
+    "manually modified and were removed: feature_fraction_bynode."
   )
 
   expect_equal(
-    extract_fit_engine(pars_fit_7)$params$feature_fraction,
+    extract_fit_engine(pars_fit_7)$params$feature_fraction_bynode,
     1
   )
 
@@ -337,7 +337,7 @@ test_that("bonsai handles mtry vs mtry_prop gracefully", {
   expect_snapshot({
     pars_fit_8 <-
       boost_tree(mtry = .5) %>%
-      set_engine("lightgbm", feature_fraction = .5) %>%
+      set_engine("lightgbm", feature_fraction_bynode = .5) %>%
       set_mode("regression") %>%
       fit(bill_length_mm ~ ., data = penguins)},
     error = TRUE
@@ -346,14 +346,14 @@ test_that("bonsai handles mtry vs mtry_prop gracefully", {
   expect_warning({
     pars_fit_9 <-
       boost_tree(mtry = 2) %>%
-      set_engine("lightgbm", feature_fraction = .5) %>%
+      set_engine("lightgbm", feature_fraction_bynode = .5) %>%
       set_mode("regression") %>%
       fit(bill_length_mm ~ ., data = penguins)},
-    "manually modified and were removed: feature_fraction."
+    "manually modified and were removed: feature_fraction_bynode."
   )
 
   expect_equal(
-    extract_fit_engine(pars_fit_9)$params$feature_fraction,
+    extract_fit_engine(pars_fit_9)$params$feature_fraction_bynode,
     2 / (ncol(penguins) - 1)
   )
 })


### PR DESCRIPTION
Closes #31.

Will PR as draft and we can revisit after conf. :)

[EDIT: no PR to parsnip needed. `mtry` is documented generically.🙂]