### PR TITLE
add files produced by covr::coverage_report() to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+*.html
 .Rproj.user
 .Rhistory
 .RData
 .Ruserdata
 docs
 inst/doc
+lib/


### PR DESCRIPTION
Contributes to #34.

To help with that issue, I wanted to first propose some new unit tests to cover currently-uncovered parts of the `{lightgbm}`  wrapper (e.g. `multi_predict._lgb.Booster()`).

I know that I can see a line-by-line coverage report on codecov, e.g. at https://app.codecov.io/gh/tidymodels/bonsai/blob/main/R/lightgbm.R, but wanted to be able to regenerate such a report while I was developing.

Since this project is using `{covr}` for codecov, I used `{covr}` like this to generate a coverage report locally:

```shell
Rscript \
    --vanilla \
    -e "covr::report(covr::package_coverage(), file = file.path(getwd(), 'coverage.html'))"
```

That worked, but left some files behind.

```text
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	coverage.html
	lib/
```

This PR proposes ignoring those files in `.gitignore`.