### PR TITLE
update train_lightgbm() docs on feature_fraction

### DIFF
--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -11,7 +11,7 @@
 #' @param num_iterations An integer for the number of boosting iterations.
 #' @param learning_rate A numeric value between zero and one to control the learning rate.
 #' @param feature_fraction Fraction of predictors that will be randomly sampled
-#' at each split.
+#'   during each iteration (i.e. for each tree).
 #' @param min_data_in_leaf A numeric value for the minimum sum of instances needed
 #'  in a child to continue to split.
 #' @param min_gain_to_split A number for the minimum loss reduction required to make a

--- a/man/train_lightgbm.Rd
+++ b/man/train_lightgbm.Rd
@@ -33,7 +33,7 @@ train_lightgbm(
 \item{learning_rate}{A numeric value between zero and one to control the learning rate.}
 
 \item{feature_fraction}{Fraction of predictors that will be randomly sampled
-at each split.}
+during each iteration (i.e. for each tree).}
 
 \item{min_data_in_leaf}{A numeric value for the minimum sum of instances needed
 in a child to continue to split.}


### PR DESCRIPTION
This PR proposes updating the documentation on `feature_fraction` in `train_lightgbm()`. That documentation currently incorrectly says that that parameter controls random sampling of features at each **split**. It actually controls random sampling of features during each **iteration**.

From the LightGBM docs (https://lightgbm.readthedocs.io/en/latest/Parameters.html);

> [`feature_fraction`](https://lightgbm.readthedocs.io/en/latest/Parameters.html#feature_fraction)
> * LightGBM will randomly select a subset of features on each iteration (tree) if `feature_fraction` is smaller than 1.0.
>
> [`feature_fraction_bynode`](https://lightgbm.readthedocs.io/en/latest/Parameters.html#feature_fraction_bynode)
> * LightGBM will randomly select a subset of features on each tree node if `feature_fraction_bynode` is smaller than 1.0.