### PR TITLE
add files produced by testthat to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .Rproj.user
 .Rhistory
 .RData
+*.rds
 .Ruserdata
 docs
 inst/doc


### PR DESCRIPTION
I tested `{bonsai}` against the development version of `{lightgbm}` today using an approach like this:

```shell
R CMD INSTALL .
cd tests
Rscript testthat.R
```

Some tests failed, and as a result `{testthat}` left behind a `.rds` file. Output of `git status`:

```text
Untracked files:
  (use "git add <file>..." to include in what will be committed)
    testthat/testthat-problems.rds
```

This PR proposes adding a rule to `.gitignore` to prevent such files from being committed to source control. Since `{bonsai}` doesn't currently ship any RDS files, I'm proposing adding a rule to ignore all of them (not just this `{testthat}` one).