### PR TITLE
remove uses of predict(reshape = TRUE) for lightgbm models (fixes #40)

### DIFF
--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -271,7 +271,7 @@ sort_args <- function(args) {
 reshape_lightgbm_multiclass_preds <- function(preds, num_rows) {
     n_preds_per_case <- length(preds) / num_rows
     if (is.vector(preds) && n_preds_per_case > 1) {
-        preds <- matrix(preds, ncol = npreds_per_case, byrow = TRUE)
+        preds <- matrix(preds, ncol = n_preds_per_case, byrow = TRUE)
     }
     preds
 }

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -271,7 +271,7 @@ sort_args <- function(args) {
 reshape_lightgbm_multiclass_preds <- function(preds, num_rows) {
     n_preds_per_case <- length(preds) / num_rows
     if (is.vector(preds) && n_preds_per_case > 1) {
-        preds <- matrix(preds, ncol = npred_per_case, byrow = TRUE)
+        preds <- matrix(preds, ncol = npreds_per_case, byrow = TRUE)
     }
     preds
 }

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -172,7 +172,9 @@ test_that("boost_tree with lightgbm",{
       verbose = -1
     )
 
-  lgbm_preds_4 <- predict(lgbm_fit_4, peng_m_c, reshape = TRUE)
+  lgbm_preds_4 <-
+      predict(lgbm_fit_4, peng_m_c) %>%
+      reshape_lightgbm_multiclass_preds(num_rows = nrow(peng_m_c))
 
   expect_equal(pars_preds_4_mtx, lgbm_preds_4)
 


### PR DESCRIPTION
Fixes #40.

As described in that issue, the `reshape` argument to `predict.lgb.Booster()` has been removed in the development version of `{lightgbm}`. This PR proposes changes to make `{bonsai}` compatible with old and new versions of `{lightgbm}` by removing the use of that argument.

### Question for Reviewers

Is the following statement true?

> generating leaf-index or SHAP feature contributions directly using `{bonsai}` is not supported

If not, then this PR might need some changes. See https://github.com/microsoft/LightGBM/blob/44fe591a60d7427d64997c37b22768a92c97c47b/R-package/R/lgb.Predictor.R#L323-L326 for reference on why I'm asking.

Thanks for your time and consideration.