### PR TITLE
test that lightgbm objective is set correctly when label is a factor

### DIFF
--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -248,6 +248,40 @@ test_that("boost_tree with lightgbm",{
 })
 
 
+test_that("bonsai correctly determines objective when label is a factor", {
+    skip_if_not_installed("lightgbm")
+    skip_if_not_installed("modeldata")
+
+    suppressPackageStartupMessages({
+        library(lightgbm)
+        library(dplyr)
+    })
+
+    data("penguins", package = "modeldata")
+    penguins <- penguins[complete.cases(penguins),]
+
+    expect_error_free({
+        bst <- train_lightgbm(
+            x = penguins[, c("bill_length_mm", "bill_depth_mm")],
+            y = penguins[["sex"]],
+            num_iterations = 5
+        )
+    })
+    expect_equal(bst$params$objective, "binary")
+    expect_equal(bst$params$num_class, 1)
+
+    expect_error_free({
+        bst <- train_lightgbm(
+            x = penguins[, c("bill_length_mm", "bill_depth_mm")],
+            y = penguins[["species"]],
+            num_iterations = 5
+        )
+    })
+    expect_equal(bst$params$objective, "multiclass")
+    expect_equal(bst$params$num_class, 3)
+})
+
+
 test_that("bonsai handles mtry vs mtry_prop gracefully", {
   skip_if_not_installed("modeldata")
 


### PR DESCRIPTION
Contributes to #34 .

Currently, `{bonsai}` contains some logic for determining the correct classification objective for LightGBM models when the provided label is a factor column.

However, that logic is not currently covered by any unit tests.

<img width="568" alt="image" src="https://user-images.githubusercontent.com/7608904/180893038-5f436ad7-f1b2-45ce-86fd-cdf854b744ef.png">

This PR proposes adding such tests, to improve the ability to catch compatibility issues between `{bonsai}` and `{lightgbm}` both evolve.

### How I tested this

Ran the tests with `{covr}` and generated a clickable coverage report before and after making these changes, with the following.

```shell
Rscript \
    --vanilla \
    -e "covr::report(covr::package_coverage(), file = file.path(getwd(), 'coverage.html'))"
```

### Notes for Reviewers

The next release of `{lightgbm}` might include support for data frames and for this sort of "automatically determine the objective for factor labels". Please subscribe to notifications on https://github.com/microsoft/LightGBM/pull/5341 and https://github.com/microsoft/LightGBM/issues/4323, and please add any relevant comments on those issues if you'd like to influence the eventual shape that that support takes.

Thanks for your time and consideration!