### PR TITLE
support multi_predict() without 'type' for lightgbm classification models

### DIFF
--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -364,7 +364,7 @@ lightgbm_by_tree <- function(tree, object, new_data, type = NULL) {
 
     nms <- names(pred)
   } else {
-    if (!is.null(type) && type == "class") {
+    if (is.null(type) || type == "class") {
       pred <- predict_lightgbm_classification_class(object, new_data, num_iteration = tree)
 
       pred <- tibble::tibble(.pred_class = factor(pred, levels = object$lvl))

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -364,7 +364,7 @@ lightgbm_by_tree <- function(tree, object, new_data, type = NULL) {
 
     nms <- names(pred)
   } else {
-    if (type == "class") {
+    if (!is.null(type) && type == "class") {
       pred <- predict_lightgbm_classification_class(object, new_data, num_iteration = tree)
 
       pred <- tibble::tibble(.pred_class = factor(pred, levels = object$lvl))

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -549,7 +549,7 @@ test_that("training wrapper passes stop_iter correctly", {
   expect_true(!is.na(pars_fit_5$fit$best_score))
 })
 
-test_that("multi_predict() produces probabilities if 'type' not given ", {
+test_that("multi_predict() predicts classes if 'type' not given ", {
     skip_if_not_installed("lightgbm")
     skip_if_not_installed("modeldata")
 
@@ -594,10 +594,10 @@ test_that("multi_predict() produces probabilities if 'type' not given ", {
     pred_tbl <- multi_preds$.pred[[1]]
     expect_s3_class(pred_tbl, "tbl_df")
 
-    # should look like probabilities
-    prob_mat <- as.matrix(pred_tbl[, paste0(".pred_", levels(penguins[["species"]]))])
-    expect_true(all(prob_mat >= 0 & prob_mat <= 1))
-    expect_equal(rowSums(prob_mat), rep(1, num_iterations), tolerance = 1e-6)
+    # should look like class predictions
+    expect_named(pred_tbl, c("trees", ".pred_class"))
+    expect_s3_class(pred_tbl[[".pred_class"]], "factor")
+    expect_true(all(as.character(pred_tbl[[".pred_class"]]) %in% levels(penguins[["species"]])))
 
     # classification (binary) ------------------------------------------------
     expect_error_free({
@@ -625,8 +625,8 @@ test_that("multi_predict() produces probabilities if 'type' not given ", {
     pred_tbl <- multi_preds$.pred[[1]]
     expect_s3_class(pred_tbl, "tbl_df")
 
-    # should look like probabilities
-    prob_mat <- as.matrix(pred_tbl[, c(".pred_female", ".pred_male")])
-    expect_true(all(prob_mat >= 0 & prob_mat <= 1))
-    expect_equal(rowSums(prob_mat), rep(1, num_iterations), tolerance = 1e-6)
+    # should look like class predictions
+    expect_named(pred_tbl, c("trees", ".pred_class"))
+    expect_s3_class(pred_tbl[[".pred_class"]], "factor")
+    expect_true(all(as.character(pred_tbl[[".pred_class"]]) %in% levels(penguins[["sex"]])))
 })


### PR DESCRIPTION
Contributes to #34.

While using `{covr}` to check this project's test coverage, I noticed that `multi_predict(...)` for `{lightgbm}` models is not currently tested.

<details><summary>how I ran {covr} (click me)</summary>

```shell
R CMD INSTALL .
Rscript \
    --vanilla \
    -e "covr::report(covr::package_coverage(), file = file.path(getwd(), 'coverage.html'))"
```

</details>

While writing some tests, I realized that running `multi_predict(...)` for a `{lightgbm}` classification model raises the following error if `"type"` is not specified.

> Error in if (type == "class") { : argument is of length zero

According to the `{parsnip}` docs ([link](https://parsnip.tidymodels.org/reference/multi_predict.html)), omitting `type` should be supported.

> When NULL, [predict()](https://rdrr.io/r/stats/predict.html) will choose an appropriate value based on the model's mode.

This PR proposes modifying `{bonsai}` such that `multi_predict(...)` produces probabilities for classification models if `"type"` is not provided.

### Notes for Reviewers

This contributes to #34 by adding test cases that cover currently-uncovered codepaths, increasing the likelihood that compatibility issues with new versions of `{lightgbm}` can be caught by this project's unit tests. As of this PR, around 90% of `{bonsai}`'s LightGBM code is covered by tests 😁 

Happy to say that the changes in this PR work with both `{lightgbm}` v3.3.2 and the latest development version (https://github.com/microsoft/LightGBM/commit/c7102e56b246cc5cd73d9787b2c837c0bc384d1e).

Thanks for your time and consideration.