### PR TITLE
remove misregistered argument in `rand_forest(engine = "partykit")`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 v0.2.1.9000 is a developmental version of the bonsai package.
 
+* Fixed issues in metadata for the `"partykit"` engine for `rand_forest()` where some engine arguments were mistakenly protected (#74).
+
 # bonsai 0.2.1
 
 * The most recent dials and parsnip releases introduced tuning integration for the lightgbm `num_leaves` engine argument! The `num_leaves` parameter sets the maximum number of nodes per tree, and is an [important tuning parameter for lightgbm](https://lightgbm.readthedocs.io/en/latest/Parameters-Tuning.html) ([tidymodels/dials#256](https://github.com/tidymodels/dials/pull/256), [tidymodels/parsnip#838](https://github.com/tidymodels/parsnip/pull/838)). With the newest version of each of dials, parsnip, and bonsai installed, tune this argument by marking the `num_leaves` engine argument for tuning when defining your model specification:

--- a/R/partykit_data.R
+++ b/R/partykit_data.R
@@ -222,16 +222,6 @@ make_rand_forest_partykit <- function() {
   parsnip::set_model_arg(
     model = "rand_forest",
     eng = "partykit",
-    parsnip = "tree_depth",
-    original = "maxdepth",
-    func = list(pkg = "dials", fun = "tree_depth"),
-    has_submodel = FALSE
-  )
-
-
-  parsnip::set_model_arg(
-    model = "rand_forest",
-    eng = "partykit",
     parsnip = "mtry",
     original = "mtry",
     func = list(pkg = "dials", fun = "mtry"),


### PR DESCRIPTION
Closes #74.