### PR TITLE
refactor `train_lightgbm()` to apply dataset arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 v0.2.1.9000 is a developmental version of the bonsai package.
 
+* Enabled passing [Dataset Parameters](https://lightgbm.readthedocs.io/en/latest/Parameters.html#dataset-parameters) to the `"lightgbm"` engine. To pass an argument that would be usually passed as an element to the `param` argument in `lightgbm::lgb.Dataset()`, pass the argument directly through the ellipses in `set_engine()`, e.g. `boost_tree() %>% set_engine("lightgbm", linear_tree = TRUE)` (#77).
+
 * Enabled case weights with the `"lightgbm"` engine (#72 by `@p-schaefer`).
 
 * Fixed issues in metadata for the `"partykit"` engine for `rand_forest()` where some engine arguments were mistakenly protected (#74).

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -247,6 +247,68 @@ test_that("boost_tree with lightgbm",{
   expect_equal(pars_preds_6_b, lgbm_preds_6)
 })
 
+test_that("bonsai applies dataset parameters (#77)", {
+  skip_if_not_installed("lightgbm")
+  skip_if_not_installed("modeldata")
+
+  suppressPackageStartupMessages({
+    library(lightgbm)
+    library(dplyr)
+  })
+
+  data("penguins", package = "modeldata")
+
+  penguins <- penguins[complete.cases(penguins),]
+
+  # regression -----------------------------------------------------------------
+  expect_error_free({
+    pars_fit_1 <-
+      boost_tree() %>%
+      set_engine("lightgbm", linear_tree = TRUE) %>%
+      set_mode("regression") %>%
+      fit(bill_length_mm ~ ., data = penguins)
+  })
+
+  expect_error_free({
+    pars_preds_1 <-
+      predict(pars_fit_1, penguins)
+  })
+
+  peng <-
+    penguins %>%
+    mutate(across(where(is.character), ~as.factor(.x))) %>%
+    mutate(across(where(is.factor), ~as.integer(.x) - 1))
+
+  peng_y <- peng$bill_length_mm
+
+  peng_m <- peng %>%
+    select(-bill_length_mm) %>%
+    as.matrix()
+
+  peng_x <-
+    lgb.Dataset(
+      data = peng_m,
+      label = peng_y,
+      params = list(feature_pre_filter = FALSE, linear_tree = TRUE),
+      categorical_feature = c(1L, 2L, 6L)
+    )
+
+  params_1 <- list(
+    objective = "regression"
+  )
+
+  lgbm_fit_1 <-
+    lightgbm::lgb.train(
+      data = peng_x,
+      params = params_1,
+      verbose = -1
+    )
+
+  lgbm_preds_1 <- predict(lgbm_fit_1, peng_m)
+
+  expect_equal(pars_preds_1$.pred, lgbm_preds_1)
+  expect_true(pars_fit_1$fit$params$linear_tree)
+})
 
 test_that("bonsai correctly determines objective when label is a factor", {
     skip_if_not_installed("lightgbm")


### PR DESCRIPTION
To close #77. The big idea is, since it only creates one `lgb.Dataset()` per `lgb.train()`, bonsai need only to be able to differentiate between:

1) main arguments to `lgb.train()` (as in `names(formals(lgb.train))` other than `params`),
2) main arguments to `lgb.Dataset()` (as in `names(formals(lgb.Dataset))` other than `params`), and
3) arguments to pass to `lgb.train(params)` OR `lgb.Dataset(params)`. Arguments to the `params` argument of either function can be concatenated together and passed to both.

This will thus open up all "Dataset parameters" to bonsai users. ~~This PR is mostly there, though I need to troubleshoot why setting `linear_tree` doesn't affect predictions for either bonsai or LightGBM in the newly added testing context and make a NEWS entry.~~ NOTE: setting `linear_tree` does indeed affect predictions for both, I must have made a mistake when checking that ad-hoc.