### PR TITLE
set bonsai as dependency for `"aorsf"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bonsai (development version)
 
+* Fixed bug where `"aorsf"` models would not successfully fit in socket cluster workers (i.e. with `plan(multisession)`) unless another engine requiring bonsai had been fitted in the worker (#85).
+
 # bonsai 0.3.0
 
 * Introduced support for accelerated oblique random forests for the `"classification"` and `"regression"` modes using the new [`"aorsf"` engine](https://github.com/ropensci/aorsf) (#78 by `@bcjaeger`). 

--- a/R/aorsf_data.R
+++ b/R/aorsf_data.R
@@ -3,8 +3,13 @@
 make_rand_forest_aorsf <- function(){
   parsnip::set_model_engine("rand_forest", "classification", "aorsf")
   parsnip::set_model_engine("rand_forest", "regression", "aorsf")
+
   parsnip::set_dependency("rand_forest", "aorsf", "aorsf", mode = "classification")
+  parsnip::set_dependency("rand_forest", "aorsf", "bonsai", mode = "classification")
+
   parsnip::set_dependency("rand_forest", "aorsf", "aorsf", mode = "regression")
+  parsnip::set_dependency("rand_forest", "aorsf", "bonsai", mode = "regression")
+
 
   parsnip::set_model_arg(
     model = "rand_forest",


### PR DESCRIPTION
Closes #85. Turns out both the extension package and the engine package need to be registered as dependencies for the socket cluster workers to know they need to load packages!

``` r
library(tidymodels)
library(bonsai)

library(future)
plan(multisession, workers = 5)

spec_rf <- 
  rand_forest(trees = 100, mtry = tune()) %>%
  set_mode("regression") %>% 
  set_engine("aorsf")

res_orf <- tune_grid(
  spec_rf,
  outcome ~ .,
  resamples = vfold_cv(sim_regression(1000))
)
#> i Creating pre-processing data to finalize unknown parameter: mtry
```

``` r

res_orf
#> # Tuning results
#> # 10-fold cross-validation 
#> # A tibble: 10 × 4
#>    splits            id     .metrics          .notes          
#>    <list>            <chr>  <list>            <list>          
#>  1 <split [900/100]> Fold01 <tibble [16 × 5]> <tibble [0 × 3]>
#>  2 <split [900/100]> Fold02 <tibble [16 × 5]> <tibble [0 × 3]>
#>  3 <split [900/100]> Fold03 <tibble [16 × 5]> <tibble [0 × 3]>
#>  4 <split [900/100]> Fold04 <tibble [16 × 5]> <tibble [0 × 3]>
#>  5 <split [900/100]> Fold05 <tibble [16 × 5]> <tibble [0 × 3]>
#>  6 <split [900/100]> Fold06 <tibble [16 × 5]> <tibble [0 × 3]>
#>  7 <split [900/100]> Fold07 <tibble [16 × 5]> <tibble [0 × 3]>
#>  8 <split [900/100]> Fold08 <tibble [16 × 5]> <tibble [0 × 3]>
#>  9 <split [900/100]> Fold09 <tibble [16 × 5]> <tibble [0 × 3]>
#> 10 <split [900/100]> Fold10 <tibble [16 × 5]> <tibble [0 × 3]>
```

<sup>Created on 2024-07-02 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>