### PR TITLE
remove `process_parallelism()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Increased the minimum R version to R 4.1.
 
-* Fixed bug where `num_threads` argument were ignored for lightgbm engine. (#105)
+* Fixed bug where `num_threads` argument were ignored for lightgbm engine (#105).
 
 # bonsai 0.3.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Increased the minimum R version to R 4.1.
 
+* Fixed bug where `num_threads` argument were ignored for lightgbm engine. (#105)
+
 # bonsai 0.3.2
 
 * Resolves a test failure ahead of an upcoming parsnip release (#95).

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -101,7 +101,6 @@ train_lightgbm <- function(
     )
 
   args <- process_bagging(args)
-  args <- process_parallelism(args)
   args <- process_objective_function(args, x, y)
 
   args <- sort_args(args)
@@ -192,17 +191,6 @@ process_objective_function <- function(args, x, y) {
         args$objective <- "multiclass"
       }
     }
-  }
-
-  args
-}
-
-# supply the number of threads as num_threads in params, clear out
-# any other thread args that might be passed as main arguments
-process_parallelism <- function(args) {
-  if (!is.null(args["num_threads"])) {
-    args$num_threads <- args[names(args) == "num_threads"]
-    args[names(args) == "num_threads"] <- NULL
   }
 
   args

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -26,7 +26,7 @@ test_that("boost_tree with lightgbm", {
   expect_no_error({
     pars_fit_1 <-
       boost_tree() |>
-      set_engine("lightgbm", num_threads = 3) |>
+      set_engine("lightgbm") |>
       set_mode("regression") |>
       fit(bill_length_mm ~ ., data = penguins)
   })

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -26,7 +26,7 @@ test_that("boost_tree with lightgbm", {
   expect_no_error({
     pars_fit_1 <-
       boost_tree() |>
-      set_engine("lightgbm") |>
+      set_engine("lightgbm", num_threads = 3) |>
       set_mode("regression") |>
       fit(bill_length_mm ~ ., data = penguins)
   })


### PR DESCRIPTION
To close #105 and close #102

The function would simply remove `num_threads` as it comes in. The issue appears to be solved by removing the function entirely.